### PR TITLE
Update gradle to 8.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,9 @@ dependencies {
     implementation group: 'org.antlr', name: 'antlr4', version: '4.9.2'
     implementation group: 'org.antlr', name: 'ST4', version: '4.3.1'
 
-    testCompile "junit:junit:4.11"
-    testCompile group: 'org.antlr', name: 'antlr4', version: '4.9.2'
-    testCompile group: 'org.antlr', name: 'ST4', version: '4.3.1'
+    testImplementation "junit:junit:4.+"
+    testImplementation group: 'org.antlr', name: 'antlr4', version: '4.9.2'
+    testImplementation group: 'org.antlr', name: 'ST4', version: '4.3.1'
 }
 
 test {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I have been trying to work with ANTLR4 grammars in a relatively recent release of openjdk, and have found that the gradle version pinned in this repo forces me into a very old JDK.

With this change I see some deprecation warnings about some project-specific configuration that will no longer be valid once gradle 9 is release... but the project compiles.